### PR TITLE
fix: Landing page hardcoded English strings (P0 bug)

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -71,7 +71,7 @@ export default async function LandingPage() {
       <section className="py-24 px-6 bg-muted/30">
         <div className="mx-auto max-w-7xl">
           <h2 className="text-4xl md:text-5xl font-bold text-center mb-16">
-            Why Savourly?
+            {t("whySavourly")}
           </h2>
 
           <div className="grid grid-cols-1 md:grid-cols-3 gap-12">
@@ -80,9 +80,9 @@ export default async function LandingPage() {
               <div className="mx-auto w-20 h-20 rounded-full bg-primary/10 flex items-center justify-center text-4xl group-hover:scale-110 transition-transform duration-200">
                 📚
               </div>
-              <h3 className="text-2xl font-semibold">Organize</h3>
+              <h3 className="text-2xl font-semibold">{t("organizeTitle")}</h3>
               <p className="text-muted-foreground leading-relaxed">
-                Keep all your recipes in one beautiful place. Never lose that family recipe again.
+                {t("organizeDescription")}
               </p>
             </div>
 
@@ -91,9 +91,9 @@ export default async function LandingPage() {
               <div className="mx-auto w-20 h-20 rounded-full bg-primary/10 flex items-center justify-center text-4xl group-hover:scale-110 transition-transform duration-200">
                 🔍
               </div>
-              <h3 className="text-2xl font-semibold">Discover</h3>
+              <h3 className="text-2xl font-semibold">{t("discoverTitle")}</h3>
               <p className="text-muted-foreground leading-relaxed">
-                Search by cuisine, difficulty, time, and more. Find the perfect recipe instantly.
+                {t("discoverDescription")}
               </p>
             </div>
 
@@ -102,9 +102,9 @@ export default async function LandingPage() {
               <div className="mx-auto w-20 h-20 rounded-full bg-primary/10 flex items-center justify-center text-4xl group-hover:scale-110 transition-transform duration-200">
                 👨‍🍳
               </div>
-              <h3 className="text-2xl font-semibold">Cook</h3>
+              <h3 className="text-2xl font-semibold">{t("cookTitle")}</h3>
               <p className="text-muted-foreground leading-relaxed">
-                Step-by-step guides with adjustable servings. Cook with confidence.
+                {t("cookDescription")}
               </p>
             </div>
           </div>
@@ -117,10 +117,10 @@ export default async function LandingPage() {
           <div className="mx-auto max-w-7xl">
             <div className="text-center mb-12">
               <h2 className="text-4xl md:text-5xl font-bold mb-4">
-                Popular Recipes
+                {t("popularRecipes")}
               </h2>
               <p className="text-xl text-muted-foreground">
-                Get inspired by delicious recipes
+                {t("getInspired")}
               </p>
             </div>
 
@@ -133,7 +133,7 @@ export default async function LandingPage() {
             <div className="text-center">
               <Link href="/recipes">
                 <Button size="lg" variant="outline" className="text-lg px-8 py-6">
-                  Explore All Recipes →
+                  {t("exploreAllRecipes")}
                 </Button>
               </Link>
             </div>
@@ -145,11 +145,11 @@ export default async function LandingPage() {
       <section className="py-24 px-6 bg-primary/5">
         <div className="mx-auto max-w-3xl text-center space-y-8">
           <h2 className="text-4xl md:text-5xl font-bold">
-            Ready to start cooking?
+            {t("readyToStartCooking")}
           </h2>
 
           <p className="text-xl text-muted-foreground">
-            Join Savourly and organize your recipes beautifully
+            {t("joinSavourly")}
           </p>
 
           <Link href="/recipes/new">

--- a/src/messages/de.json
+++ b/src/messages/de.json
@@ -21,7 +21,19 @@
     "subtitle": "Deine persönliche Rezeptsammlung",
     "getStarted": "Loslegen",
     "browseRecipes": "Rezepte durchsuchen",
-    "addFirstRecipe": "Dein erstes Rezept hinzufügen"
+    "addFirstRecipe": "Dein erstes Rezept hinzufügen",
+    "whySavourly": "Warum Savourly?",
+    "organizeTitle": "Organisieren",
+    "organizeDescription": "Bewahre all deine Rezepte an einem schönen Ort auf. Verliere nie wieder ein Familienrezept.",
+    "discoverTitle": "Entdecken",
+    "discoverDescription": "Suche nach Küche, Schwierigkeit, Zeit und mehr. Finde sofort das perfekte Rezept.",
+    "cookTitle": "Kochen",
+    "cookDescription": "Schritt-für-Schritt-Anleitungen mit anpassbaren Portionen. Koche mit Vertrauen.",
+    "popularRecipes": "Beliebte Rezepte",
+    "getInspired": "Lass dich von köstlichen Rezepten inspirieren",
+    "exploreAllRecipes": "Alle Rezepte erkunden →",
+    "readyToStartCooking": "Bereit zum Kochen?",
+    "joinSavourly": "Werde Teil von Savourly und organisiere deine Rezepte auf schöne Weise"
   },
   "recipe": {
     "title": "Rezept",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -21,7 +21,19 @@
     "subtitle": "Your personal recipe collection",
     "getStarted": "Get Started",
     "browseRecipes": "Browse Recipes",
-    "addFirstRecipe": "Add Your First Recipe"
+    "addFirstRecipe": "Add Your First Recipe",
+    "whySavourly": "Why Savourly?",
+    "organizeTitle": "Organize",
+    "organizeDescription": "Keep all your recipes in one beautiful place. Never lose that family recipe again.",
+    "discoverTitle": "Discover",
+    "discoverDescription": "Search by cuisine, difficulty, time, and more. Find the perfect recipe instantly.",
+    "cookTitle": "Cook",
+    "cookDescription": "Step-by-step guides with adjustable servings. Cook with confidence.",
+    "popularRecipes": "Popular Recipes",
+    "getInspired": "Get inspired by delicious recipes",
+    "exploreAllRecipes": "Explore All Recipes →",
+    "readyToStartCooking": "Ready to start cooking?",
+    "joinSavourly": "Join Savourly and organize your recipes beautifully"
   },
   "recipe": {
     "title": "Recipe",


### PR DESCRIPTION
## Summary
- Adds translation keys to both `en.json` and `de.json` for all hardcoded strings on landing page
- Replaces 10 hardcoded English strings with `t()` calls in `src/app/[locale]/page.tsx`

## Changes
**Strings replaced:**
- "Why Savourly?"
- "Organize" + description
- "Discover" + description
- "Cook" + description
- "Popular Recipes"
- "Get inspired by delicious recipes"
- "Explore All Recipes →"
- "Ready to start cooking?"
- "Join Savourly and organize your recipes beautifully"

## Test Plan
- [x] `npm run build` passes
- [x] `npm run test` passes
- [x] All landing page text now uses i18n translations
- [x] Both EN and DE translations provided

Fixes #31

Generated with [Claude Code](https://claude.com/claude-code)