### PR TITLE
fix: RecipeForm module-level mutable state (P1 bug)

### DIFF
--- a/src/app/[locale]/recipes/new/recipe-form.tsx
+++ b/src/app/[locale]/recipes/new/recipe-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useActionState, useState } from "react";
+import { useActionState, useRef, useState } from "react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -28,22 +28,23 @@ interface InstructionRow {
   content: string;
 }
 
-let nextIngredientId = 1;
-let nextInstructionId = 1;
-
-function createIngredientRow(): IngredientRow {
-  return { id: nextIngredientId++, name: "", amount: "", unit: "" };
-}
-
-function createInstructionRow(): InstructionRow {
-  return { id: nextInstructionId++, content: "" };
-}
-
 export default function RecipeForm() {
   const t = useTranslations("recipe");
   const tDiff = useTranslations("difficulty");
   const tCommon = useTranslations("common");
   const [state, formAction, isPending] = useActionState(createRecipe, {});
+
+  const nextIngredientId = useRef(1);
+  const nextInstructionId = useRef(1);
+
+  const createIngredientRow = (): IngredientRow => {
+    return { id: nextIngredientId.current++, name: "", amount: "", unit: "" };
+  };
+
+  const createInstructionRow = (): InstructionRow => {
+    return { id: nextInstructionId.current++, content: "" };
+  };
+
   const [ingredients, setIngredients] = useState<IngredientRow[]>([
     createIngredientRow(),
   ]);


### PR DESCRIPTION
## Summary
- Moves module-level mutable variables `nextIngredientId` and `nextInstructionId` into component scope using `useRef`
- Moves helper functions `createIngredientRow` and `createInstructionRow` into the component
- Prevents state leakage between component instances and across remounts

## Changes
**Before:**
```typescript
let nextIngredientId = 1;
let nextInstructionId = 1;
```

**After:**
```typescript
const nextIngredientId = useRef(1);
const nextInstructionId = useRef(1);
```

## Why This Matters
Module-level mutable state persists across component instances and survives remounts. This could cause:
- ID collisions when multiple forms exist
- IDs not resetting when navigating away and back
- Unexpected behavior in testing

## Test Plan
- [x] `npm run build` passes
- [x] `npm run test` passes
- [x] Form functionality unchanged
- [x] IDs properly scoped to component instance

Fixes #25

Generated with [Claude Code](https://claude.com/claude-code)