### PR TITLE
Add error boundaries (error.tsx) for resilient UX

### DIFF
--- a/src/app/[locale]/error.test.tsx
+++ b/src/app/[locale]/error.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import ErrorBoundary from "./error";
+
+// Mock next-intl
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => {
+    const translations: Record<string, string> = {
+      somethingWentWrong: "Something went wrong",
+      errorDescription: "We encountered an unexpected error. Please try again or return home.",
+      tryAgain: "Try again",
+      goHome: "Go home",
+      errorId: "Error ID",
+    };
+    return translations[key] || key;
+  },
+}));
+
+// Mock Link component
+vi.mock("@/i18n/routing", () => ({
+  Link: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+describe("Error Boundary", () => {
+  it("renders error message", () => {
+    const mockReset = vi.fn();
+    const mockError = new Error("Test error");
+
+    render(<ErrorBoundary error={mockError} reset={mockReset} />);
+
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+  });
+
+  it("renders Try again button", () => {
+    const mockReset = vi.fn();
+    const mockError = new Error("Test error");
+
+    render(<ErrorBoundary error={mockError} reset={mockReset} />);
+
+    expect(screen.getByRole("button", { name: "Try again" })).toBeInTheDocument();
+  });
+
+  it("renders Go home link", () => {
+    const mockReset = vi.fn();
+    const mockError = new Error("Test error");
+
+    render(<ErrorBoundary error={mockError} reset={mockReset} />);
+
+    expect(screen.getByText("Go home")).toBeInTheDocument();
+  });
+});

--- a/src/app/[locale]/error.tsx
+++ b/src/app/[locale]/error.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Link } from "@/i18n/routing";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  const t = useTranslations("error");
+
+  return (
+    <div className="min-h-screen flex items-center justify-center px-6 py-24">
+      <Card className="max-w-lg w-full">
+        <CardHeader>
+          <CardTitle className="text-3xl text-center">
+            {t("somethingWentWrong")}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-6 text-center">
+          <p className="text-muted-foreground text-lg">
+            {t("errorDescription")}
+          </p>
+
+          <div className="flex flex-col sm:flex-row gap-3 justify-center">
+            <Button onClick={reset} size="lg">
+              {t("tryAgain")}
+            </Button>
+            <Link href="/">
+              <Button variant="outline" size="lg">
+                {t("goHome")}
+              </Button>
+            </Link>
+          </div>
+
+          {error.digest && (
+            <p className="text-xs text-muted-foreground mt-6">
+              {t("errorId")}: {error.digest}
+            </p>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/[locale]/recipes/[id]/error.test.tsx
+++ b/src/app/[locale]/recipes/[id]/error.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import ErrorBoundary from "./error";
+
+// Mock next-intl
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => {
+    const translations: Record<string, string> = {
+      recipeErrorTitle: "Recipe error",
+      recipeErrorDescription: "We couldn't load this recipe. Please try again or browse other recipes.",
+      tryAgain: "Try again",
+      backToRecipes: "Back to recipes",
+      goHome: "Go home",
+      errorId: "Error ID",
+    };
+    return translations[key] || key;
+  },
+}));
+
+// Mock Link component
+vi.mock("@/i18n/routing", () => ({
+  Link: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+describe("Recipe Error Boundary", () => {
+  it("renders recipe-specific error message", () => {
+    const mockReset = vi.fn();
+    const mockError = new Error("Test error");
+
+    render(<ErrorBoundary error={mockError} reset={mockReset} />);
+
+    expect(screen.getByText("Recipe error")).toBeInTheDocument();
+  });
+
+  it("renders Try again button", () => {
+    const mockReset = vi.fn();
+    const mockError = new Error("Test error");
+
+    render(<ErrorBoundary error={mockError} reset={mockReset} />);
+
+    expect(screen.getByRole("button", { name: "Try again" })).toBeInTheDocument();
+  });
+
+  it("renders Back to recipes link", () => {
+    const mockReset = vi.fn();
+    const mockError = new Error("Test error");
+
+    render(<ErrorBoundary error={mockError} reset={mockReset} />);
+
+    expect(screen.getByText("Back to recipes")).toBeInTheDocument();
+  });
+});

--- a/src/app/[locale]/recipes/[id]/error.tsx
+++ b/src/app/[locale]/recipes/[id]/error.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Link } from "@/i18n/routing";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  const t = useTranslations("error");
+
+  return (
+    <div className="min-h-screen flex items-center justify-center px-6 py-24">
+      <Card className="max-w-lg w-full">
+        <CardHeader>
+          <CardTitle className="text-3xl text-center">
+            {t("recipeErrorTitle")}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-6 text-center">
+          <p className="text-muted-foreground text-lg">
+            {t("recipeErrorDescription")}
+          </p>
+
+          <div className="flex flex-col sm:flex-row gap-3 justify-center">
+            <Button onClick={reset} size="lg">
+              {t("tryAgain")}
+            </Button>
+            <Link href="/recipes">
+              <Button variant="outline" size="lg">
+                {t("backToRecipes")}
+              </Button>
+            </Link>
+            <Link href="/">
+              <Button variant="ghost" size="lg">
+                {t("goHome")}
+              </Button>
+            </Link>
+          </div>
+
+          {error.digest && (
+            <p className="text-xs text-muted-foreground mt-6">
+              {t("errorId")}: {error.digest}
+            </p>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/messages/de.json
+++ b/src/messages/de.json
@@ -90,5 +90,15 @@
     "invalidUrl": "Ungültige URL",
     "minLength": "Mindestens {min} Zeichen",
     "maxLength": "Maximal {max} Zeichen"
+  },
+  "error": {
+    "somethingWentWrong": "Etwas ist schief gelaufen",
+    "errorDescription": "Ein unerwarteter Fehler ist aufgetreten. Bitte versuche es erneut oder kehre zur Startseite zurück.",
+    "tryAgain": "Erneut versuchen",
+    "goHome": "Zur Startseite",
+    "errorId": "Fehler-ID",
+    "recipeErrorTitle": "Rezeptfehler",
+    "recipeErrorDescription": "Dieses Rezept konnte nicht geladen werden. Bitte versuche es erneut oder stöbere in anderen Rezepten.",
+    "backToRecipes": "Zurück zu Rezepten"
   }
 }

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -90,5 +90,15 @@
     "invalidUrl": "Invalid URL",
     "minLength": "Minimum {min} characters",
     "maxLength": "Maximum {max} characters"
+  },
+  "error": {
+    "somethingWentWrong": "Something went wrong",
+    "errorDescription": "We encountered an unexpected error. Please try again or return home.",
+    "tryAgain": "Try again",
+    "goHome": "Go home",
+    "errorId": "Error ID",
+    "recipeErrorTitle": "Recipe error",
+    "recipeErrorDescription": "We couldn't load this recipe. Please try again or browse other recipes.",
+    "backToRecipes": "Back to recipes"
   }
 }


### PR DESCRIPTION
## Summary
- Created `error.tsx` at app root level (`src/app/[locale]/error.tsx`) to catch errors across the whole app
- Created `error.tsx` at recipe detail level (`src/app/[locale]/recipes/[id]/error.tsx`) to catch recipe-specific errors
- Added comprehensive unit tests for both error boundaries
- Added i18n translations (EN + DE) for all error messages

## Features
- User-friendly error messages with proper i18n support
- "Try again" button that calls the `reset()` function
- Navigation options: "Go home" for app-level errors, "Back to recipes" for recipe-level errors
- Displays error digest when available for debugging
- Styled consistently with Savourly design system using shadcn/ui components

## Test plan
- [x] Unit tests pass for both error boundaries
- [x] Build passes with zero errors
- [x] Error messages use next-intl translations
- [x] Both EN and DE translations added
- [x] Error pages use "use client" directive
- [x] Styled consistently with app design

Fixes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)