### PR TITLE
fix: multiple UI and data integrity bugs

### DIFF
--- a/src/app/[locale]/recipes/[id]/recipe-detail.tsx
+++ b/src/app/[locale]/recipes/[id]/recipe-detail.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import Image from "next/image";
-import Link from "next/link";
+import { Link } from "@/i18n/routing";
 import { useTranslations } from "next-intl";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -138,7 +138,7 @@ export function RecipeDetail({ recipe, cookingLogs, currentUserId, isFavorited }
                 size={16}
                 className={favorited ? "fill-primary text-primary" : ""}
               />
-              {favorited ? tCommon("unsave") : tCommon("saved")}
+              {favorited ? tCommon("unsave") : tCommon("save")}
             </Button>
           )}
           {isOwner && (

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -30,8 +30,10 @@ export function Navigation() {
   const navLinks = [
     { href: "/", label: t("title") },
     { href: "/recipes/discover", label: t("discover") },
-    ...(session?.user ? [{ href: "/recipes", label: t("recipes") }] : []),
-    { href: "/recipes/new", label: t("addRecipe") },
+    ...(session?.user ? [
+      { href: "/recipes", label: t("recipes") },
+      { href: "/recipes/new", label: t("addRecipe") },
+    ] : []),
   ];
 
   return (


### PR DESCRIPTION
## Summary
- **Swapped bookmark labels**: Button showed "Saved" when recipe was NOT bookmarked. Now correctly shows "Save" / "Unsave"
- **Foreign key enforcement**: Added `PRAGMA foreign_keys = ON` so CASCADE deletes on recipes properly clean up ingredients, instructions, cooking logs, and favorites
- **DB singleton race condition**: Stored initialization promise instead of resolved client to prevent concurrent requests from running schema/seed twice
- **Nav link visibility**: "Add Recipe" link now hidden for unauthenticated users
- **Edit link i18n**: Changed `next/link` import to `@/i18n/routing` Link so the edit button includes the locale prefix

## Test plan
- [x] `npm run build` passes
- [x] All 50 unit tests pass
- [ ] Verify bookmark button shows "Save" on unfavorited recipes and "Unsave" on favorited ones
- [ ] Verify deleting a recipe also removes its ingredients/instructions from the DB
- [ ] Verify "Add Recipe" nav link is hidden when logged out
- [ ] Verify edit button on recipe detail navigates correctly with locale prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)